### PR TITLE
Merge config instead of extend to allow for nested options

### DIFF
--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -157,7 +157,7 @@ Shipit.prototype.initConfig = function (config) {
   if (!config[this.environment])
     throw new Error('Environment "' + this.environment + '" not found in config');
 
-  this.config = _.extend({
+  this.config = _.merge({
     branch: 'master',
     keepReleases: 5,
     shallowClone: false


### PR DESCRIPTION
I'm writing some tasks that add things to the shipit config object.
Using `merge` instead of `extend` allows nested keys and have all the defaults merge in.

Example (see `db`):
```
  var config = {
    options: {
      workspace: '/tmp/<%= pkg.name %>',
      repositoryUrl: '<%= pkg.repository.url %>',
      keepReleases: 3,
      shallowClone: true,
      ignores: [
        '.git',
        'config',
        'grunt',
        'merges',
        'node_modules',
      ],
      servers: '<%= pkg.deploy.user %>@<%= pkg.deploy.server %>',
      db: {
        dumpDir: 'db',
        local: {
          host     : 'localhost',
          adapter  : 'mysql',
          username : 'root',
          password : 'root',
          socket   : '/Applications/MAMP/tmp/mysql/mysql.sock',
          database : 'xxx_local',
        },
        remote: {}
      }

    },
    development: {
      deployTo: '/home/<%= pkg.deploy.user %>/apps/<%= pkg.deploy.appName %>/shipit',
      branch: 'shipit',
      db: {
        remote: {
          host     : '127.0.0.1',
          adapter  : 'mysql',
          username : 'xxx',
          password : 'xxx',
          database : 'xxx',
        }
      }
    },
  };

```