### PR TITLE
Log commands from ship.local, so it mirrors shipit.remote.

### DIFF
--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -184,6 +184,8 @@ Shipit.prototype.local = function (command, options, cb) {
   }
 
   return new Promise(function (resolve, reject) {
+    shipit.log('Running "%s" on local.', command);
+
     options = _.defaults(options || {}, {
       maxBuffer: 1000 * 1024
     });


### PR DESCRIPTION
It seemed to me `shipit.local` should log the commands it is running, as that is what `shipit.remote` does.