### PR TITLE
Pass --info=progress2 to rsync

### DIFF
--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -241,7 +241,8 @@ Shipit.prototype.remoteCopy = function (src, dest, options, callback) {
   }
 
   options = _.defaults(options || {}, {
-    ignores: this.config && this.config.ignores ? this.config.ignores : []
+    ignores: this.config && this.config.ignores ? this.config.ignores : [],
+    rsync: ['--info=progress2']
   });
 
   return this.pool.copy(src, dest, options, callback);

--- a/test/shipit.js
+++ b/test/shipit.js
@@ -95,12 +95,14 @@ describe('Shipit', function () {
 
     it('should accept options for shipit.pool.copy', function () {
       shipit.remoteCopy('src', 'dest', {
-        direction: 'remoteToLocal'
+        direction: 'remoteToLocal',
+        rsync: ['--info=progress2']
       });
 
       expect(shipit.pool.copy).to.be.calledWith('src', 'dest', {
         direction: 'remoteToLocal',
-        ignores: []
+        ignores: [],
+        rsync: ['--info=progress2']
       });
     });
 


### PR DESCRIPTION
Depends on https://github.com/neoziro/ssh-pool/pull/7

`--info=progress2` seems like sensible default to show some feedback during the transfer.