### PR TITLE
pass strict option into ssh connection pool

### DIFF
--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -140,7 +140,7 @@ Shipit.prototype.initSshPool = function () {
     throw new Error('Servers not filled');
 
   var servers = _.isArray(this.config.servers) ? this.config.servers : [this.config.servers];
-  this.pool = new sshPool.ConnectionPool(servers, _.extend({}, this.options, _.pick(this.config, 'key')));
+  this.pool = new sshPool.ConnectionPool(servers, _.extend({}, this.options, _.pick(this.config, 'key', 'strict')));
   return this;
 };
 


### PR DESCRIPTION
There was mention of the strict option being added in a ticket I commented in and I see that it's supported in the ssh-pool module but it wasn't being passed into that module from shipit.