### PR TITLE
Emit "init" event for plugins to listen for

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ shipit.on('built', function () {
 });
 ```
 
+Shipit emits the `init` event once initialized, before any tasks are run.
+
 ### Methods
 
 #### shipit.task(name, [deps], fn)

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -48,6 +48,7 @@ util.inherits(Shipit, Orchestrator);
  */
 
 Shipit.prototype.initialize = function () {
+  this.emit('init');
   return this.initSshPool();
 };
 


### PR DESCRIPTION
Using `shipit.on('start')` seems to be problematic for Grunt users. This provides an event that can be listened for before any other tasks are run.

Fixes #94 

Also needed for https://github.com/shipitjs/grunt-shipit/issues/58, https://github.com/timkelty/shipit-shared/issues/32