### PR TITLE
Adding shipit-composer to third party plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ module.exports = function (shipit) {
 - [shipit-npm](https://github.com/callerc1/shipit-npm)
 - [shipit-aws](https://github.com/KrashStudio/shipit-aws)
 - [shipit-captain](https://github.com/timkelty/shipit-captain/)
+- [shipit-composer](https://github.com/jeremyzahner/shipit-composer)
 
 ## Who use Shipit?
 


### PR DESCRIPTION
Hi there!

I created shipit-composer as a composer wrapper for installing composer dependencies during deployments.

I just added it to the readme.

Cheers!