### PR TITLE
Adding shipit-bower to third party list

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ module.exports = function (shipit) {
 - [shipit-npm](https://github.com/callerc1/shipit-npm)
 - [shipit-aws](https://github.com/KrashStudio/shipit-aws)
 - [shipit-captain](https://github.com/timkelty/shipit-captain/)
+- [shipit-bower](https://github.com/willsteinmetz/shipit-bower)
 
 ## Who use Shipit?
 


### PR DESCRIPTION
I created a modified version of [shipit-npm](https://github.com/callerc1/shipit-npm) to run Bower tasks. This pull-request is just adding a link to that package to the README file under the third-party list.