### PR TITLE
Solve #115, add warnTask and disallowTask options for the shipitfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ module.exports = function (shipit) {
       repositoryUrl: 'https://github.com/user/repo.git',
       ignores: ['.git', 'node_modules'],
       rsync: ['--del'],
+      warnTasks: ['nuke'],
       keepReleases: 2,
       key: '/path/to/key',
       shallowClone: true
@@ -229,11 +230,6 @@ Log using Shipit, same API as `console.log`.
 shipit.log('hello %s', 'world');
 ```
 
-## Dependencies
-
-- [OpenSSH](http://www.openssh.com/) 5+
-- [rsync](https://rsync.samba.org/) 3+
-
 ### Customising environments
 
 You can overwrite all default variables defined as part of the `default` object.
@@ -266,6 +262,43 @@ module.exports = function (shipit) {
   ...
 };
 ```
+
+#### Avoiding human error with `warnTasks` and `disallowTasks`
+
+You can set allow, warn, and disallow settings per environment in your shipitfile (***these settings only matter when shipit is run from the CLI***):
+
+```js
+module.exports = function (shipit) {
+  shipit.initConfig({
+    default: {},
+    staging: {
+      warnTasks: ['wipe'],
+      disallowTasks: ['nuke'],
+      servers: 'myserver.com'
+    }
+  });
+};
+
+  ...
+  shipit.task('wipe', function () {
+    return shipit.remote('rm -rf *');
+  });
+  shipit.task('nuke', function () {
+    return shipit.remote('rm -rf ../../*');
+  });
+  ...
+};
+```
+ - `warnTasks` is an array of tasks that prompt the user to confirm the environment name before they can run.
+ - `disallowTasks` is an array of tasks the user cannot run (from CLI) in that environment
+ - `allowTasks` doesn't do anything currently, as tasks are allowed by default, but may serve your syntactic sugar needs.
+
+
+## Dependencies
+
+- [OpenSSH](http://www.openssh.com/) 5+
+- [rsync](https://rsync.samba.org/) 3+
+
 
 ## Known Plugins
 

--- a/bin/shipit
+++ b/bin/shipit
@@ -80,7 +80,7 @@ function initShipit(env, shipfile, tasks) {
 
 
   if (Array.isArray(shipit.config.disallowTasks)) {
-    if (!tasks.every( (currentValue) => {
+    if (!tasks.every( function(currentValue) {
         if (shipit.config.disallowTasks.indexOf(currentValue) > -1) {
           console.log('Task \'' + currentValue + '\' is a disallowed task for \'' + shipit.environment + '\', aborting task(s)!')
           return false;
@@ -92,7 +92,7 @@ function initShipit(env, shipfile, tasks) {
     }
   }
   if (Array.isArray(shipit.config.warnTasks)) {
-    if (!tasks.every( (currentValue) => {
+    if (!tasks.every( function(currentValue) {
         if (shipit.config.warnTasks.indexOf(currentValue) > -1) {
           console.log('Task \'' + currentValue + '\' needs verification to run in \'' + shipit.environment + '\'.')
           return false;

--- a/bin/shipit
+++ b/bin/shipit
@@ -5,6 +5,7 @@ var interpret = require('interpret');
 var v8flags = require('v8flags');
 var Liftoff = require('liftoff');
 var argv = require('minimist')(process.argv.slice(2));
+var prompt = require('prompt');
 var Shipit = require('../lib/shipit');
 var pkg = require('../package.json');
 
@@ -48,7 +49,7 @@ function invoke(env) {
   // Run the 'default' task if no task is specified
   var tasks = argv._.slice(1);
   if (tasks.length === 0) {
-    tasks.push("default");
+    tasks.push('default');
   }
 
   try {
@@ -77,9 +78,53 @@ function initShipit(env, shipfile, tasks) {
   // Initialize shipit.
   shipit.initialize();
 
-  // Run tasks.
-  shipit.start(tasks);
 
+  if (Array.isArray(shipit.config.disallowTasks)) {
+    if (!tasks.every( (currentValue) => {
+        if (shipit.config.disallowTasks.indexOf(currentValue) > -1) {
+          console.log('Task \'' + currentValue + '\' is a disallowed task for \'' + shipit.environment + '\', aborting task(s)!')
+          return false;
+        }
+        return true;
+      }) ) {
+      
+      exit(1);
+    }
+  }
+  if (Array.isArray(shipit.config.warnTasks)) {
+    if (!tasks.every( (currentValue) => {
+        if (shipit.config.warnTasks.indexOf(currentValue) > -1) {
+          console.log('Task \'' + currentValue + '\' needs verification to run in \'' + shipit.environment + '\'.')
+          return false;
+        }
+        return true;
+      }) ) {
+      prompt.start();
+      prompt.get([{
+        name: 'confirmEnv',
+        description: '\nTo run please type \'' + shipit.environment + '\'',
+        type: 'string',
+        required: true
+      }], function(err, results) {
+        if (results.confirmEnv === shipit.environment) {
+          prompt.stop();
+          shipit.start(tasks);
+        } else {
+          prompt.stop();
+          console.log('Failed to confirm, aborting task(s)!')
+          exit(1);
+        }
+      });
+    } else {
+      // If there are warn tasks, but our tasks aren't one of them - run tasks.
+      shipit.start(tasks);
+    }
+  } else {
+    // If there are no warn tasks and tasks are not disallowed - run tasks.
+    shipit.start(tasks);
+  }
+
+  //Regardless if there are warn or disallow tasks, we need to set handlers for if tasks run.
   shipit.on('task_err', function () {
     exit(1);
   });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "minimist": "^1.1.0",
     "orchestrator": "^0.3.7",
     "pretty-hrtime": "^1.0.0",
+    "prompt": "^1.0.0",
     "ssh-pool": "^1.0.0",
     "stream-line-wrapper": "^0.1.1",
     "v8flags": "^2.0.2"

--- a/shipitfile.js
+++ b/shipitfile.js
@@ -2,6 +2,7 @@ module.exports = function (shipit) {
   shipit.initConfig({
     default: {},
     staging: {
+      warnTasks: ['test'],
       servers: 'myserver.com'
     }
   });

--- a/shipitfile.js
+++ b/shipitfile.js
@@ -2,7 +2,6 @@ module.exports = function (shipit) {
   shipit.initConfig({
     default: {},
     staging: {
-      warnTasks: ['test'],
       servers: 'myserver.com'
     }
   });


### PR DESCRIPTION
TLDR Changes:
- Added code in bin/shipit to make use of `warnTask` and `disallowTask` options in the shipitfile.
- Added Appropriate entry near the bottom of the README in the "Customising environments" section, moved the "Customising environments" section to a spot that makes more sense, namely above the dependencies section (so dependencies section can be nice and visible as the last entry).

Did not add tests, as no other CLI-functionality is tested currently in this repo (something that needs to change before 2.0? Or are we waiting?)
### Readme Entry:
#### Avoiding human error with `warnTasks` and `disallowTasks`

You can set allow, warn, and disallow settings per environment in your shipitfile (**_these settings only matter when shipit is run from the CLI**_):

``` js
module.exports = function (shipit) {
  shipit.initConfig({
    default: {},
    staging: {
      warnTasks: ['wipe'],
      disallowTasks: ['nuke'],
      servers: 'myserver.com'
    }
  });
};

  ...
  shipit.task('wipe', function () {
    return shipit.remote('rm -rf *');
  });
  shipit.task('nuke', function () {
    return shipit.remote('rm -rf ../../*');
  });
  ...
};
```
- `warnTasks` is an array of tasks that prompt the user to confirm the environment name before they can run.
- `disallowTasks` is an array of tasks the user cannot run (from CLI) in that environment
- `allowTasks` doesn't do anything currently, as tasks are allowed by default, but may serve your syntactic sugar needs.
