### PR TITLE
Make environment-specific server configurations fully override the default one.

### DIFF
--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -162,7 +162,10 @@ Shipit.prototype.initConfig = function (config) {
     keepReleases: 5,
     shallowClone: false
   }, config.default || {}, config[this.environment]);
-  this.config.servers = config[this.environment].servers || this.config.servers;
+
+  if(this.config.servers)
+    this.config.servers = config[this.environment].servers || this.config.servers;
+
   return this;
 };
 

--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -162,6 +162,7 @@ Shipit.prototype.initConfig = function (config) {
     keepReleases: 5,
     shallowClone: false
   }, config.default || {}, config[this.environment]);
+  this.config.servers = config[this.environment].servers || this.config.servers;
   return this;
 };
 

--- a/test/shipit.js
+++ b/test/shipit.js
@@ -46,13 +46,14 @@ describe('Shipit', function () {
 
   describe('#initConfig', function () {
     it('should initialize config', function () {
-      shipit.initConfig({default: {foo: 'bar'}, stage: {kung: 'foo'}});
+      shipit.initConfig({default: {foo: 'bar', servers: ['1', '2']}, stage: {kung: 'foo', servers: ['3']}});
 
       expect(shipit.config).to.be.deep.equal({
         branch: 'master',
         keepReleases: 5,
         foo: 'bar',
         kung: 'foo',
+        servers: ['3'],
         shallowClone: false
       });
     });


### PR DESCRIPTION
This would change the behavior of the configuration merging to allow for shorter lists of servers to completely override a longer set of defaults. Further discussion can be found in #137.
