### PR TITLE
Missing Promise

### DIFF
--- a/bin/shipit
+++ b/bin/shipit
@@ -7,6 +7,7 @@ var Liftoff = require('liftoff');
 var argv = require('minimist')(process.argv.slice(2));
 var Shipit = require('../lib/shipit');
 var pkg = require('../package.json');
+var Promise = require('bluebird');
 
 // Initialize cli.
 var cli = new Liftoff({


### PR DESCRIPTION
Shipit v1.5.1 stops due to a missing Promise

```
# shipit staging deploy
Promise is not defined
```