### PR TITLE
Add support for the `cwd` option on remote commands.

### DIFF
--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -220,6 +220,10 @@ Shipit.prototype.local = function (command, options, cb) {
  */
 
 Shipit.prototype.remote = function (command, options, cb) {
+  if (options && options.cwd) {
+    command = 'cd "' + options.cwd.replace(/"/g, '\\"') + '" && ' + command;
+    delete options.cwd;
+  }
   return this.pool.run(command, options, cb);
 };
 

--- a/test/shipit.js
+++ b/test/shipit.js
@@ -81,6 +81,12 @@ describe('Shipit', function () {
 
       expect(shipit.pool.run).to.be.calledWith('my-command');
     });
+
+    it('should cd and run command on pool', function () {
+      shipit.remote('my-command', {cwd: '/my-directory'});
+
+      expect(shipit.pool.run).to.be.calledWith('cd "/my-directory" && my-command', {});
+    });
   });
 
   describe('#remoteCopy', function () {


### PR DESCRIPTION
Addresses the issue discussed in #9.

Some of the `config` options (*e.g.* `env` and `timeout`) work as expected when passed to `child_process.exec` but `cwd` changes the local directory while most people probably expect it to change the remote one. This can lead to `ENOENT` errors that don't make it immediately clear what the underlying problem is. This pull request allows calls like `shipit.remote('the-command', { cwd: '/the/directory' })` to be remotely executed as  `cd "/the/directory" && the-command`.