### PR TITLE
Instructions how to install shipit-deploy and run with npx in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Tweet][twitter-badge]][twitter]
 
 ```
-npm install --save-dev shipit-cli
+npm install -g shipit-cli
 ```
 
 Shipit is an automation engine and a deployment tool.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,13 @@
 [![Star on GitHub][github-star-badge]][github-star]
 [![Tweet][twitter-badge]][twitter]
 
+## Install shipit command line tools globally
 ```
 npm install -g shipit-cli
+```
+## Install shipit-deploy as development dependency in your project
+```
+npm install --save-dev shipit-deploy
 ```
 
 Shipit is an automation engine and a deployment tool.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ## Install shipit command line tools and shipit-deploy in your project
 ```
 npm install --save-dev shipit-cli
+npm install --save-dev shipit-deploy
 ```
 
 Shipit is an automation engine and a deployment tool.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,9 @@
 [![Star on GitHub][github-star-badge]][github-star]
 [![Tweet][twitter-badge]][twitter]
 
-## Install shipit command line tools globally
+## Install shipit command line tools and shipit-deploy in your project
 ```
-npm install -g shipit-cli
-```
-## Install shipit-deploy as development dependency in your project
-```
-npm install --save-dev shipit-deploy
+npm install --save-dev shipit-cli
 ```
 
 Shipit is an automation engine and a deployment tool.
@@ -55,9 +51,9 @@ module.exports = shipit => {
 }
 ```
 
-2.  Run deploy command `shipit staging deploy`
+2.  Run deploy command using [npx](https://www.npmjs.com/package/npx): `npx shipit staging deploy`
 
-3.  You can rollback using `shipit staging rollback`
+3.  You can rollback using `npx shipit staging rollback`
 
 ## Recipes
 


### PR DESCRIPTION
In the readme, install shipit-cli globally instead of dev-dependency to be able to use it from the command line. Without installing it globally (or only as dev-dependency), `shipit` cannot be used as command line program.