### PR TITLE
Add option to remove or keep workspace

### DIFF
--- a/packages/shipit-deploy/README.md
+++ b/packages/shipit-deploy/README.md
@@ -157,6 +157,12 @@ Type: `String`
 
 Parameter to pass to `cp` to copy the previous release. Non NTFS filesystems support `-r`. Default: `-a`
 
+### removeWorkspace
+
+Type: `Boolean`
+
+Purge workspace after update. Default: `true`.
+
 ## Variables
 
 Several variables are attached during the deploy and the rollback process:

--- a/packages/shipit-deploy/src/extendShipit.js
+++ b/packages/shipit-deploy/src/extendShipit.js
@@ -50,6 +50,7 @@ function extendShipit(shipit) {
     branch: 'master',
     keepReleases: 5,
     shallowClone: true,
+    removeWorkspace: true,
     gitLogFormat: '%h: %s - %an',
     ...shipit.config,
   }

--- a/packages/shipit-deploy/src/tasks/deploy/update.js
+++ b/packages/shipit-deploy/src/tasks/deploy/update.js
@@ -135,7 +135,7 @@ const updateTask = shipit => {
     }
 
     async function removeWorkspace() {
-      if (shipit.config.shallowClone) {
+      if (shipit.config.removeWorkspace) {
         shipit.log(`Removing workspace "${shipit.workspace}"`)
         await rmfr(shipit.workspace)
         shipit.log(chalk.green('Workspace removed.'))

--- a/packages/shipit-deploy/src/tasks/deploy/update.test.js
+++ b/packages/shipit-deploy/src/tasks/deploy/update.test.js
@@ -226,8 +226,8 @@ describe('deploy:update task', () => {
     })
   })
 
-  it('should remove workspace when shallow cloning', async () => {
-    shipit.config.shallowClone = true
+  it('should remove workspace when removal is enabled', async () => {
+    shipit.config.removeWorkspace = true
     stubShipit(shipit)
     rmfr.mockClear()
     expect(rmfr).not.toHaveBeenCalled()
@@ -235,8 +235,8 @@ describe('deploy:update task', () => {
     expect(rmfr).toHaveBeenCalledWith('/tmp/workspace')
   })
 
-  it('should keep workspace when not shallow cloning', async () => {
-    shipit.config.shallowClone = false
+  it('should keep workspace when removal is disabled', async () => {
+    shipit.config.removeWorkspace = false
     stubShipit(shipit)
     rmfr.mockClear()
     expect(rmfr).not.toHaveBeenCalled()


### PR DESCRIPTION
Hello,

it would be helpful for me to use Shipit also without `deploy:fetch` step, e.g. when application is already fetched within CI. But it's not easily possible now since `deploy:update` deletes the workspace so deletes also Shipit itself (if it's part of deployed application).

This merge request adds possibility to enable or disable the workspace removal step. After that, Shipit can deploy application without fetching the repository.

```
    // Configuration
    default: {
        workspace: './',
        removeWorkspace: false
    }

```

```
    // Deploy from working directory without repository fetch
    utils.registerTask(shipit, 'deploy:fetch', async () => {

        // Set the workspace variable which is originally set in overridden deploy:fetch
        // This variable is needed in deploy:update and some other tasks
        shipit.workspace = shipit.config.workspace;

        shipit.emit('fetched');
    });
```

There is still one thing which could be improved and that's need of defining `shipit.workspace = shipit.config.workspace` when `deploy:fetch` task is overridden.
