### PR TITLE
Update copy method deprecation warning to v5

### DIFF
--- a/packages/ssh-pool/src/Connection.js
+++ b/packages/ssh-pool/src/Connection.js
@@ -11,7 +11,7 @@ import { formatRawCommand } from './commands/raw'
 import { formatRmCommand } from './commands/rm'
 import { joinCommandArgs } from './commands/util'
 import { parseRemote, formatRemote } from './remote'
-import { exec, series, deprecateV3 } from './util'
+import { exec, series, deprecateV5 } from './util'
 
 const tmpName = async options =>
   new Promise((resolve, reject) =>
@@ -105,7 +105,7 @@ class Connection {
    * @throws {ExecError}
    */
   async copy(src, dest, { direction, ...options } = {}) {
-    deprecateV3(
+    deprecateV5(
       '"copy" method is deprecated, please use "copyToRemote", "copyFromRemote", "scpCopyToRemote" or "scpCopyFromRemote".',
     )
     if (direction === 'remoteToLocal')

--- a/packages/ssh-pool/src/Connection.js
+++ b/packages/ssh-pool/src/Connection.js
@@ -11,7 +11,7 @@ import { formatRawCommand } from './commands/raw'
 import { formatRmCommand } from './commands/rm'
 import { joinCommandArgs } from './commands/util'
 import { parseRemote, formatRemote } from './remote'
-import { exec, series, deprecateV5 } from './util'
+import { exec, series, deprecateV3, deprecateV5 } from './util'
 
 const tmpName = async options =>
   new Promise((resolve, reject) =>

--- a/packages/ssh-pool/src/util.js
+++ b/packages/ssh-pool/src/util.js
@@ -44,3 +44,7 @@ export const exec = async (cmd, options, childModifier) =>
 export function deprecateV3(...args) {
   console.warn(...args, 'It will break in v3.0.0.')
 }
+
+export function deprecateV5(...args) {
+  console.warn(...args, 'It will break in v5.0.0.')
+}


### PR DESCRIPTION
First steps for #201. Does not close the issue, it just clarifies the warning. Further changes will need to be made to remove the root cause of the warning.