### PR TITLE
Fixes Directory Permissions

### DIFF
--- a/packages/shipit-deploy/src/tasks/deploy/fetch.js
+++ b/packages/shipit-deploy/src/tasks/deploy/fetch.js
@@ -22,7 +22,7 @@ const fetchTask = shipit => {
         shipit.log('Create workspace...')
         /* eslint-disable no-param-reassign */
         if (shipit.config.shallowClone) {
-          const tmpDir = await tmp.dir()
+          const tmpDir = await tmp.dir({mode: "0755"})
           shipit.workspace = tmpDir.path
         } else {
           shipit.workspace = shipit.config.workspace


### PR DESCRIPTION
This fixes https://github.com/shipitjs/shipit/issues/189

So the issue wasn't with the directory creation on the server, but the creation of the tmp workspace directory. 