### PR TITLE
 Proxy Command Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules/
 packages/*/lib
 coverage/

--- a/packages/ssh-pool/src/Connection.js
+++ b/packages/ssh-pool/src/Connection.js
@@ -78,14 +78,14 @@ class Connection {
    * @returns {ExecResult}
    * @throws {ExecError}
    */
-  async run(command, { tty: ttyOption, cwd, ...cmdOptions } = {}) {
+  async run(command, { tty: ttyOption, cwd,proxy, ...cmdOptions } = {}) {
     let tty = ttyOption
     if (command.startsWith('sudo') && typeof ttyOption === 'undefined') {
       deprecateV3('You should set "tty" option explictly when you use "sudo".')
       tty = true
     }
     this.log('Running "%s" on host "%s".', command, this.remote.host)
-    const cmd = this.buildSSHCommand(command, { tty, cwd })
+    const cmd = this.buildSSHCommand(command, { tty, cwd ,proxy})
     return this.runLocally(cmd, cmdOptions)
   }
 
@@ -163,7 +163,7 @@ class Connection {
    * @returns {ExecResult}
    * @throws {ExecError}
    */
-  async scpCopyToRemote(src, dest, { ignores, ...cmdOptions } = {}) {
+  async scpCopyToRemote(src, dest, { ignores, proxy,...cmdOptions } = {}) {
     const archive = path.basename(await tmpName({ postfix: '.tar.gz' }))
     const srcDir = path.dirname(src)
     const remoteDest = `${formatRemote(this.remote)}:${dest}`
@@ -185,8 +185,10 @@ class Connection {
       formatCdCommand({ folder: srcDir }),
       '&&',
       formatScpCommand({
+
         port: this.remote.port,
         key: this.options.key,
+        proxy,
         src: archive,
         dest: remoteDest,
       }),
@@ -233,7 +235,7 @@ class Connection {
    * @returns {MultipleExecResult}
    * @throws {ExecError}
    */
-  async scpCopyFromRemote(src, dest, { ignores, ...cmdOptions } = {}) {
+  async scpCopyFromRemote(src, dest, { ignores,proxy, ...cmdOptions } = {}) {
     const archive = path.basename(await tmpName({ postfix: '.tar.gz' }))
     const srcDir = path.dirname(src)
     const srcArchive = path.join(srcDir, archive)
@@ -253,8 +255,10 @@ class Connection {
     const createDestFolder = formatMkdirCommand({ folder: dest })
 
     const copy = formatScpCommand({
+
       port: this.remote.port,
       key: this.options.key,
+      proxy,
       src: remoteSrcArchive,
       dest,
     })
@@ -301,6 +305,7 @@ class Connection {
       key: this.options.key,
       strict: this.options.strict,
       tty: this.options.tty,
+      proxy: this.options.proxy,
       verbosityLevel: this.options.verbosityLevel,
       remote: formatRemote(this.remote),
       command: formatRawCommand({ command, asUser: this.options.asUser }),
@@ -329,6 +334,7 @@ class Connection {
       key: this.options.key,
       strict: this.options.strict,
       tty: this.options.tty,
+      proxy: this.options.proxy,
     })
 
     const cmd = formatRsyncCommand({

--- a/packages/ssh-pool/src/commands/scp.js
+++ b/packages/ssh-pool/src/commands/scp.js
@@ -3,7 +3,7 @@ import { joinCommandArgs, requireArgs } from './util'
 export function formatScpCommand({ port, key, proxy, src, dest }) {
   requireArgs(['src', 'dest'], { src, dest }, 'scp')
   let args = ['scp']
-  if (proxy) args = [...args, '-o', `ProxyCommand ${proxy}`]
+  if (proxy) args = [...args, '-o', `"ProxyCommand ${proxy}"`]
   if (port) args = [...args, '-P', port]
   if (key) args = [...args, '-i', key]
   args = [...args, src, dest]

--- a/packages/ssh-pool/src/commands/scp.js
+++ b/packages/ssh-pool/src/commands/scp.js
@@ -1,8 +1,9 @@
 import { joinCommandArgs, requireArgs } from './util'
 
-export function formatScpCommand({ port, key, src, dest }) {
+export function formatScpCommand({ port, key, proxy, src, dest }) {
   requireArgs(['src', 'dest'], { src, dest }, 'scp')
   let args = ['scp']
+  if (proxy) args = [...args, '-o', `ProxyCommand ${proxy}`]
   if (port) args = [...args, '-P', port]
   if (key) args = [...args, '-i', key]
   args = [...args, src, dest]

--- a/packages/ssh-pool/src/commands/scp.test.js
+++ b/packages/ssh-pool/src/commands/scp.test.js
@@ -27,7 +27,11 @@ describe('scp', () => {
         formatScpCommand({ src: 'file.js', dest: 'foo/', port: 3000 }),
       ).toBe('scp -P 3000 file.js foo/')
     })
-
+    it('should support proxy', () => {
+      expect(
+        formatScpCommand({ src: 'file.js', dest: 'foo/', port: 3000, proxy:'ssh -W %h:%p user@bastion'  }),
+      ).toBe('scp -o "ProxyCommand ssh -W %h:%p user@bastion" -P 3000 file.js foo/')
+    })
     it('should support key', () => {
       expect(
         formatScpCommand({

--- a/packages/ssh-pool/src/commands/ssh.js
+++ b/packages/ssh-pool/src/commands/ssh.js
@@ -10,6 +10,7 @@ export function formatSshCommand({
   strict,
   tty,
   remote,
+  proxy,
   cwd,
   command,
   verbosityLevel,
@@ -26,6 +27,8 @@ export function formatSshCommand({
   if (tty) args = [...args, '-tt']
   if (port) args = [...args, '-p', port]
   if (key) args = [...args, '-i', key]
+  if (proxy)
+    args = [...args, '-o', `ProxyCommand='${proxy}'`]
   if (strict !== undefined)
     args = [...args, '-o', `StrictHostKeyChecking=${strict}`]
   if (remote) args = [...args, remote]

--- a/packages/ssh-pool/src/commands/ssh.test.js
+++ b/packages/ssh-pool/src/commands/ssh.test.js
@@ -14,6 +14,10 @@ describe('ssh', () => {
       expect(formatSshCommand({ key: 'foo' })).toBe('ssh -i foo')
     })
 
+    it('should support proxy', () => {
+          expect(formatSshCommand({ proxy: 'ssh -W %h:%p user@bastion' })).toBe(
+            "ssh -o ProxyCommand='ssh -W %h:%p user@bastion'",
+          )
     it('should support strict', () => {
       expect(formatSshCommand({ strict: true })).toBe(
         'ssh -o StrictHostKeyChecking=true',

--- a/packages/ssh-pool/src/commands/ssh.test.js
+++ b/packages/ssh-pool/src/commands/ssh.test.js
@@ -15,9 +15,8 @@ describe('ssh', () => {
     })
 
     it('should support proxy', () => {
-          expect(formatSshCommand({ proxy: 'ssh -W %h:%p user@bastion' })).toBe(
-            "ssh -o ProxyCommand='ssh -W %h:%p user@bastion'",
-          )
+      expect(formatSshCommand({ proxy: 'ssh -W %h:%p user@bastion' })).toBe("ssh -o ProxyCommand='ssh -W %h:%p user@bastion'")
+    })
     it('should support strict', () => {
       expect(formatSshCommand({ strict: true })).toBe(
         'ssh -o StrictHostKeyChecking=true',


### PR DESCRIPTION
I need to be able to deploy to a server behind a bastion host.  This requires adding a proxy to the ssh command.  The arguments need to be passed into ssh-pool.  

 I saw that there was a version of this on the old version of ssh-pool. The previous attempt got reverted.  I saw a note recommending making it into a plugin instead of modifying ssh-pool. To do that I would need to modify shipit-cli so you could configure what kind of connection is loaded in. 
I'd be happy to pursue whatever line of work would mean it will get merged in so I don't have to keep mine shipit separate. 

I'm still confirming that these commands work as planned.
