### PR TITLE
Added event after the ssh pool is setup

### DIFF
--- a/packages/shipit-cli/README.md
+++ b/packages/shipit-cli/README.md
@@ -128,6 +128,26 @@ Log using Shipit, same API as `console.log`.
 shipit.log('hello %s', 'world')
 ```
 
+## Workflow tasks
+
+When the system initializes it automatically emits events: 
+  * Emit event "init"
+  * Emit event "init:after_ssh_pool"
+
+Each shipit task also generates events:
+  * Emit event "task_start"
+  * Emit event "task_stop"
+  * Emit event "task_err"
+  * Emit event "task_not_found"
+
+Inside the task events, you can test for the task name.
+```js
+ shipit.on("task_start",  (event) => {
+   if (event.task == "first_task"){
+     shipit.log("I'm the first task");
+   }
+  });
+```
 ## License
 
 MIT

--- a/packages/shipit-cli/src/Shipit.js
+++ b/packages/shipit-cli/src/Shipit.js
@@ -166,6 +166,7 @@ class Shipit extends Orchestrator {
 
     this.pool = new ConnectionPool(servers, options)
 
+    this.emit('init:ssh_pool')
     return this
   }
 

--- a/packages/shipit-cli/src/Shipit.js
+++ b/packages/shipit-cli/src/Shipit.js
@@ -166,7 +166,7 @@ class Shipit extends Orchestrator {
 
     this.pool = new ConnectionPool(servers, options)
 
-    this.emit('init:ssh_pool')
+    this.emit('init:after_ssh_pool')
     return this
   }
 

--- a/packages/shipit-cli/src/Shipit.test.js
+++ b/packages/shipit-cli/src/Shipit.test.js
@@ -52,6 +52,14 @@ describe('Shipit', () => {
       shipit.initialize()
       expect(shipit.initSshPool).toBeCalled()
     })
+    it('should emit a "init" event', async () => {
+	    const spy = jest.fn()
+	    shipit.on('init', spy)
+	    expect(spy).toHaveBeenCalledTimes(0)
+      	    shipit.initialize()
+	    expect(spy).toHaveBeenCalledTimes(1)
+    })
+
   })
 
   describe('#initSshPool', () => {
@@ -62,6 +70,14 @@ describe('Shipit', () => {
       expect(shipit.pool).toEqual(expect.any(ConnectionPool))
       expect(shipit.pool.connections[0].remote.user).toBe('deploy')
       expect(shipit.pool.connections[0].remote.host).toBe('my-server')
+    })
+    it('should emit a "init:after_ssh_pool" event', async () => {
+      shipit.config = { servers: ['deploy@my-server'] }
+	    const spy = jest.fn()
+	    shipit.on('init:after_ssh_pool', spy)
+	    expect(spy).toHaveBeenCalledTimes(0)
+      	    shipit.initSshPool()
+	    expect(spy).toHaveBeenCalledTimes(1)
     })
   })
 


### PR DESCRIPTION
The current emit(init) happens too early.  In order to improve configuration options for the shipit-bastion I need a hook after the pool is setup so I can modify it with the options for the proxy I'm inserting.  This should not impact any current users but should make shipit more flexible. 