### PR TITLE
fix: enable Git Bash shells on Windows to successfully deploy

### DIFF
--- a/packages/shipit-deploy/src/tasks/deploy/update.js
+++ b/packages/shipit-deploy/src/tasks/deploy/update.js
@@ -1,5 +1,6 @@
 import utils from 'shipit-utils'
 import path from 'path2/posix'
+import p from 'path';
 import moment from 'moment'
 import chalk from 'chalk'
 import util from 'util'
@@ -62,10 +63,7 @@ const updateTask = shipit => {
         rsync: '--del',
       }
       const rsyncFrom = shipit.config.rsyncFrom || shipit.workspace
-      const uploadDirPath = path.resolve(
-        rsyncFrom,
-        shipit.config.dirToCopy || '',
-      )
+      const uploadDirPath = p.resolve(rsyncFrom, shipit.config.dirToCopy || '');
 
       shipit.log('Copy project to remote servers.')
 


### PR DESCRIPTION
Thanks for developing this tool, it's very nice and does a good job of replicating Capistrano-like deployments which I always enjoyed in Ruby.

*Reason for PR*
We work with both Mac (aka Bash) and Windows environments in our team, and while Mac works fine with `shipit` as is, using Git Bash on Windows (currently our only option on Windows 8) gives file path errors as follows:
```
Running 'deploy:update' task...
Running "if [ -h /home/some-user/some-app/current ]; then readlink /home/some-user/some-app/current; fi" on host "52.xxx.xxx.xx".
@52.xxx.xxx.xx releases/20190621014635
Previous release found.
Running "if [ -f /home/some-user/some-app/releases/20190621014635/REVISION ]; then cat /home/some-user/some-app/releases/20190621014635/REVISION 2>/dev/null; fi;" on host "52.xxx.xxx.xx".
@52.xxx.xxx.xx cbc52d95
Previous revision found.
Create release path "/home/some-user/some-app/releases/20190621025624"
Running "mkdir -p /home/some-user/some-app/releases/20190621025624" on host "52.xxx.xxx.xx".
Release path created.
Copy previous release to "/home/some-user/some-app/releases/20190621025624"
Running "cp -a /home/some-user/some-app/releases/20190621014635/. /home/some-user/some-app/releases/20190621025624" on host "52.xxx.xxx.xx".
Copy project to remote servers.
"copy" method is deprecated, please use "copyToRemote", "copyFromRemote", "scpCopyToRemote" or "scpCopyFromRemote". It will break in v5.0.0.
@52.xxx.xxx.xx-err The filename, directory name, or volume label syntax is incorrect.
'deploy:update' errored after 41 s
Error: Command failed: cd /C:\Users\SomePath\AppData\Local\Temp && tar -czf tmp-252606NBnTFVZprRM.tar.gz tmp-25260mF1plc2PFbWT
The filename, directory name, or volume label syntax is incorrect.

    at ChildProcess.exithandler (child_process.js:275:12)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:925:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
```

The reason being is that `path2/posix` is being used in the call to `path.resolve` for a local system path.  This works fine on Linux/Mac, but on Windows, at least in Git Bash, the path resolves incorrectly, putting a forward-slash `/` before the path: `/C:\Users\SomePath\AppData\Local\Temp`, which causes the above error.

I have tested this branch on Windows/Git Bash and Mac/iTerm/Bash and it works successfully.