### PR TITLE
Added option to add config file and known host file

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ Type: `String`
 
 Path to SSH config file.
 
+#### knownHostFile
+
+Type: `String`
+
+Path to SSH known host file.
+
 #### servers
 
 Type: `String` or `Array<String>`

--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ Type: `String`
 
 Path to SSH key.
 
+#### configFile
+
+Type: `String`
+
+Path to SSH config file.
+
 #### servers
 
 Type: `String` or `Array<String>`

--- a/packages/ssh-pool/README.md
+++ b/packages/ssh-pool/README.md
@@ -36,6 +36,7 @@ Create a new connection to run command on a remote server.
 @param {Stream} [options.stdout] Stdout stream
 @param {Stream} [options.stderr] Stderr stream
 @param {string} [options.key] SSH key
+@param {string} [options.configFile] Path to SSH config file
 @param {function} [options.log] Log method
 @param {boolean} [options.asUser] Use a custom user to run command
 @param {number} [options.verbosityLevel] SSH verbosity level: 0 (none), 1 (-v), 2 (-vv), 3+ (-vvv)

--- a/packages/ssh-pool/README.md
+++ b/packages/ssh-pool/README.md
@@ -37,6 +37,7 @@ Create a new connection to run command on a remote server.
 @param {Stream} [options.stderr] Stderr stream
 @param {string} [options.key] SSH key
 @param {string} [options.configFile] Path to SSH config file
+@param {string} [options.knownHostFile] Path to SSH known host file
 @param {function} [options.log] Log method
 @param {boolean} [options.asUser] Use a custom user to run command
 @param {number} [options.verbosityLevel] SSH verbosity level: 0 (none), 1 (-v), 2 (-vv), 3+ (-vvv)

--- a/packages/ssh-pool/src/Connection.js
+++ b/packages/ssh-pool/src/Connection.js
@@ -299,6 +299,7 @@ class Connection {
     return formatSshCommand({
       port: this.remote.port,
       key: this.options.key,
+      configFile: this.options.configFile,
       strict: this.options.strict,
       tty: this.options.tty,
       verbosityLevel: this.options.verbosityLevel,
@@ -327,6 +328,7 @@ class Connection {
     const sshCommand = formatSshCommand({
       port: this.remote.port,
       key: this.options.key,
+      configFile: this.options.configFile,
       strict: this.options.strict,
       tty: this.options.tty,
     })

--- a/packages/ssh-pool/src/Connection.js
+++ b/packages/ssh-pool/src/Connection.js
@@ -300,6 +300,7 @@ class Connection {
       port: this.remote.port,
       key: this.options.key,
       configFile: this.options.configFile,
+      knownHostFile: this.options.knownHostFile,
       strict: this.options.strict,
       tty: this.options.tty,
       verbosityLevel: this.options.verbosityLevel,
@@ -329,6 +330,7 @@ class Connection {
       port: this.remote.port,
       key: this.options.key,
       configFile: this.options.configFile,
+      knownHostFile: this.options.knownHostFile,
       strict: this.options.strict,
       tty: this.options.tty,
     })

--- a/packages/ssh-pool/src/Connection.test.js
+++ b/packages/ssh-pool/src/Connection.test.js
@@ -117,6 +117,20 @@ describe('Connection', () => {
       )
     })
 
+    it('should use config file if present', async () => {
+      connection = new Connection({
+        remote: 'user@host',
+        configFile: '/path/to/config-file',
+      })
+
+      await connection.run('my-command -x')
+      expect(exec).toHaveBeenCalledWith(
+        'ssh -F /path/to/config-file user@host "my-command -x"',
+        { maxBuffer: 1024000 },
+        expect.any(Function),
+      )
+    })
+
     it('should use port if present', async () => {
       connection = new Connection({ remote: 'user@host:12345' })
       await connection.run('my-command -x')

--- a/packages/ssh-pool/src/Connection.test.js
+++ b/packages/ssh-pool/src/Connection.test.js
@@ -131,6 +131,20 @@ describe('Connection', () => {
       )
     })
 
+    it('should use known host file if present', async () => {
+      connection = new Connection({
+        remote: 'user@host',
+        knownHostFile: '/path/to/known-host-file',
+      })
+
+      await connection.run('my-command -x')
+      expect(exec).toHaveBeenCalledWith(
+        'ssh -o UserKnownHostsFile=/path/to/known-host-file user@host "my-command -x"',
+        { maxBuffer: 1024000 },
+        expect.any(Function),
+      )
+    })
+
     it('should use port if present', async () => {
       connection = new Connection({ remote: 'user@host:12345' })
       await connection.run('my-command -x')

--- a/packages/ssh-pool/src/commands/ssh.js
+++ b/packages/ssh-pool/src/commands/ssh.js
@@ -12,6 +12,7 @@ export function formatSshCommand({
   remote,
   cwd,
   command,
+  configFile,
   verbosityLevel,
 }) {
   let args = ['ssh']
@@ -33,6 +34,7 @@ export function formatSshCommand({
   if (tty) args = [...args, '-tt']
   if (port) args = [...args, '-p', port]
   if (key) args = [...args, '-i', key]
+  if (configFile) args = [...args, '-F', configFile]
   if (strict !== undefined)
     args = [...args, '-o', `StrictHostKeyChecking=${strict}`]
   if (remote) args = [...args, remote]

--- a/packages/ssh-pool/src/commands/ssh.js
+++ b/packages/ssh-pool/src/commands/ssh.js
@@ -13,7 +13,8 @@ export function formatSshCommand({
   cwd,
   command,
   configFile,
-  verbosityLevel,
+  knownHostFile,
+  verbosityLevel
 }) {
   let args = ['ssh']
   if (verbosityLevel) {
@@ -35,6 +36,7 @@ export function formatSshCommand({
   if (port) args = [...args, '-p', port]
   if (key) args = [...args, '-i', key]
   if (configFile) args = [...args, '-F', configFile]
+  if (knownHostFile) args = [...args, '-o', `UserKnownHostsFile=${knownHostFile}`]
   if (strict !== undefined)
     args = [...args, '-o', `StrictHostKeyChecking=${strict}`]
   if (remote) args = [...args, remote]

--- a/packages/ssh-pool/src/commands/ssh.js
+++ b/packages/ssh-pool/src/commands/ssh.js
@@ -14,7 +14,7 @@ export function formatSshCommand({
   command,
   configFile,
   knownHostFile,
-  verbosityLevel
+  verbosityLevel,
 }) {
   let args = ['ssh']
   if (verbosityLevel) {

--- a/packages/ssh-pool/src/commands/ssh.test.js
+++ b/packages/ssh-pool/src/commands/ssh.test.js
@@ -33,6 +33,18 @@ describe('ssh', () => {
       )
     })
 
+    it('should support known host file', () => {
+      expect(formatSshCommand({ knownHostFile: '/known-host-file' })).toBe(
+        'ssh -o UserKnownHostsFile=/known-host-file',
+      )
+    })
+
+    it('should support known host file and strict check', () => {
+      expect(formatSshCommand({ knownHostFile: '/known-host-file', strict: true })).toBe(
+        'ssh -o UserKnownHostsFile=/known-host-file -o StrictHostKeyChecking=true',
+      )
+    })
+
     it('should support remote', () => {
       expect(
         formatSshCommand({

--- a/packages/ssh-pool/src/commands/ssh.test.js
+++ b/packages/ssh-pool/src/commands/ssh.test.js
@@ -14,6 +14,10 @@ describe('ssh', () => {
       expect(formatSshCommand({ key: 'foo' })).toBe('ssh -i foo')
     })
 
+    it('should support config file', () => {
+      expect(formatSshCommand({ configFile: '/config-file' })).toBe('ssh -F /config-file')
+    })
+
     it('should support strict', () => {
       expect(formatSshCommand({ strict: true })).toBe(
         'ssh -o StrictHostKeyChecking=true',


### PR DESCRIPTION
These are some things that I need to deploy my project.

Another solution would be to accept an array of additional ssh configs so they can be appended with the `-o`. This would remove the need for a ssh config file and the known hosts option because those can then be easily added in the additional ssh configs array.

Let me know what you think is the better solution and I will edit the PR accordingly.