### PR TITLE
fix: after cd, must run the specified drive letter

### DIFF
--- a/packages/ssh-pool/src/commands/cd.js
+++ b/packages/ssh-pool/src/commands/cd.js
@@ -1,12 +1,14 @@
+import path from 'path'
 import { joinCommandArgs, requireArgs } from './util'
+
+const isWin = /^win/.test(process.platform)
 
 export function formatCdCommand({ folder }) {
   requireArgs(['folder'], { folder }, 'cd')
   const args = ['cd', folder]
-  const isWin = /^win/.test(process.platform)
-  if (isWin && folder.indexOf('/') > 0) {
-    const drive = folder.slice(0, 2)
-    args.push(`&& ${drive}`)
+  const { root } = path.parse(folder)
+  if (isWin && root !== '/') {
+    args.push(`&& ${root}`)
   }
   return joinCommandArgs(args)
 }

--- a/packages/ssh-pool/src/commands/cd.js
+++ b/packages/ssh-pool/src/commands/cd.js
@@ -3,5 +3,11 @@ import { joinCommandArgs, requireArgs } from './util'
 export function formatCdCommand({ folder }) {
   requireArgs(['folder'], { folder }, 'cd')
   const args = ['cd', folder]
+  const isWin = /^win/.test(process.platform)
+  const startStr = folder.slice(0, 1)
+  if (isWin && folder.indexOf('/') > 0) {
+    const drive = folder.slice(0, 2)
+    args.push(`&& ${drive}`)
+  }
   return joinCommandArgs(args)
 }

--- a/packages/ssh-pool/src/commands/cd.js
+++ b/packages/ssh-pool/src/commands/cd.js
@@ -4,7 +4,6 @@ export function formatCdCommand({ folder }) {
   requireArgs(['folder'], { folder }, 'cd')
   const args = ['cd', folder]
   const isWin = /^win/.test(process.platform)
-  const startStr = folder.slice(0, 1)
   if (isWin && folder.indexOf('/') > 0) {
     const drive = folder.slice(0, 2)
     args.push(`&& ${drive}`)

--- a/packages/ssh-pool/src/commands/cd.js
+++ b/packages/ssh-pool/src/commands/cd.js
@@ -7,8 +7,9 @@ export function formatCdCommand({ folder }) {
   requireArgs(['folder'], { folder }, 'cd')
   const args = ['cd', folder]
   const { root } = path.parse(folder)
+  const drive = root.replace(path.sep, '')
   if (isWin && root !== '/') {
-    args.push(`&& ${root}`)
+    args.push(`&& ${drive}`)
   }
   return joinCommandArgs(args)
 }


### PR DESCRIPTION
on the Windows, If my project is on the D drive(`D:/projce/demo`), after running `cd C:/user`, I will not enter the C drive immediately, we need to run `C:`, then we enter `C:/user`.

so, this PR want to fix this.