### PR TITLE
Adding support of `asUser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ The server can use the shorthand syntax or an object:
 
 ### Shipit Deploy configuration
 
+#### asUser
+
+Type: `String`
+
+Allows you to ‘become’ another user, different from the user that logged into the machine (remote user). 
+
 #### deleteOnRollback
 
 Type: `Boolean`, default to `false`

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+process.env.FORCE_COLOR=0;
+
 module.exports = {
   testEnvironment: 'node',
   roots: ['packages'],

--- a/packages/shipit-cli/src/Shipit.js
+++ b/packages/shipit-cli/src/Shipit.js
@@ -157,6 +157,7 @@ class Shipit extends Orchestrator {
     const options = {
       ...this.options,
       key: this.config.key,
+      asUser: this.config.asUser,
       strict: this.config.strict,
       verbosityLevel:
         this.config.verboseSSHLevel === undefined

--- a/packages/shipit-cli/tests/integration.test.js
+++ b/packages/shipit-cli/tests/integration.test.js
@@ -3,12 +3,13 @@ import { exec } from 'ssh-pool'
 
 const shipitCli = path.resolve(__dirname, '../src/cli.js')
 const shipitFile = path.resolve(__dirname, './sandbox/shipitfile.babel.js')
+const babelNode = require.resolve('@babel/node/bin/babel-node');
 
 describe('shipit-cli', () => {
   it('should run a local task', async () => {
-    const { stdout } = await exec(
-      `babel-node ${shipitCli} --shipitfile ${shipitFile} test localHello`,
-    )
+    let { stdout } = await exec(`FORCE_COLOR=0 ${babelNode} ${shipitCli} --shipitfile ${shipitFile} test localHello`)
+    stdout = stdout.trim();
+
     expect(stdout).toMatch(/Running 'localHello' task.../)
     expect(stdout).toMatch(/Running "echo "hello"" on local./)
     expect(stdout).toMatch(/@ hello/)
@@ -16,9 +17,9 @@ describe('shipit-cli', () => {
   }, 10000)
 
   it('should run a remote task', async () => {
-    const { stdout } = await exec(
-      `babel-node ${shipitCli} --shipitfile ${shipitFile} test remoteUser`,
-    )
+    let { stdout } = await exec(`FORCE_COLOR=0 ${babelNode} ${shipitCli} --shipitfile ${shipitFile} test remoteUser`)
+    stdout = stdout.trim();
+
     expect(stdout).toMatch(/Running 'remoteUser' task.../)
     expect(stdout).toMatch(/Running "echo \$USER" on host "test.shipitjs.com"./)
     expect(stdout).toMatch(/@test.shipitjs.com deploy/)
@@ -27,7 +28,7 @@ describe('shipit-cli', () => {
 
   it('should work with "~"', async () => {
     const { stdout } = await exec(
-      `babel-node ${shipitCli} --shipitfile ${shipitFile} test cwdSsh`,
+      `${babelNode} ${shipitCli} --shipitfile ${shipitFile} test cwdSsh`,
     )
     expect(stdout).toMatch(/@test.shipitjs.com \/home\/deploy\/\.ssh/)
   }, 10000)

--- a/packages/shipit-deploy/tests/integration.test.js
+++ b/packages/shipit-deploy/tests/integration.test.js
@@ -4,12 +4,13 @@ import { exec } from 'ssh-pool'
 
 const shipitCli = path.resolve(__dirname, '../../shipit-cli/src/cli.js')
 const shipitFile = path.resolve(__dirname, './sandbox/shipitfile.babel.js')
+const babelNode = require.resolve('@babel/node/bin/babel-node');
 
 describe('shipit-cli', () => {
   it('should run a local task', async () => {
     try {
       await exec(
-        `babel-node ${shipitCli} --shipitfile ${shipitFile} test deploy`,
+        `${babelNode} ${shipitCli} --shipitfile ${shipitFile} test deploy`,
       )
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -19,7 +20,7 @@ describe('shipit-cli', () => {
     }
 
     const { stdout: lsReleases } = await exec(
-      `babel-node ${shipitCli} --shipitfile ${shipitFile} test ls-releases`,
+      `${babelNode} ${shipitCli} --shipitfile ${shipitFile} test ls-releases`,
     )
 
     const latestRelease = lsReleases
@@ -28,7 +29,7 @@ describe('shipit-cli', () => {
       .match(/\d{14}/)[0]
 
     const { stdout: lsCurrent } = await exec(
-      `babel-node ${shipitCli} --shipitfile ${shipitFile} test ls-current`,
+      `${babelNode} ${shipitCli} --shipitfile ${shipitFile} test ls-current`,
     )
 
     const currentRelease = lsCurrent
@@ -36,5 +37,5 @@ describe('shipit-cli', () => {
       .match(/releases\/(\d{14})/)[1]
 
     expect(latestRelease).toBe(currentRelease)
-  }, 25000)
+  }, 30000)
 })

--- a/packages/ssh-pool/src/Connection.js
+++ b/packages/ssh-pool/src/Connection.js
@@ -334,6 +334,7 @@ class Connection {
     })
 
     const cmd = formatRsyncCommand({
+      asUser: this.options.asUser,
       src,
       dest,
       remoteShell: sshCommand,

--- a/packages/ssh-pool/src/Connection.test.js
+++ b/packages/ssh-pool/src/Connection.test.js
@@ -312,7 +312,7 @@ describe('Connection', () => {
           expect.any(Function),
         ])
         expect(exec.mock.calls[4]).toEqual([
-          'ssh user@host "cd /x/y/z && tar --strip-components=1 -xzf foo.tar.gz"',
+          'ssh user@host "cd /x/y/z && tar -xzf foo.tar.gz"',
           { maxBuffer: 1024000 },
           expect.any(Function),
         ])
@@ -351,7 +351,7 @@ describe('Connection', () => {
           expect.any(Function),
         ])
         expect(exec.mock.calls[4]).toEqual([
-          'cd /x/y/z && tar --strip-components=1 -xzf foo.tar.gz',
+          'cd /x/y/z && tar -xzf foo.tar.gz',
           { maxBuffer: 1024000 },
           expect.any(Function),
         ])
@@ -392,7 +392,7 @@ describe('Connection', () => {
           expect.any(Function),
         ])
         expect(exec.mock.calls[4]).toEqual([
-          'ssh -p 12345 -i /path/to/key user@host "cd /x/y/z && tar --strip-components=1 -xzf foo.tar.gz"',
+          'ssh -p 12345 -i /path/to/key user@host "cd /x/y/z && tar -xzf foo.tar.gz"',
           { maxBuffer: 1024000 },
           expect.any(Function),
         ])
@@ -481,8 +481,8 @@ describe('Connection', () => {
         '/src/dir',
         'user@host:/dest/dir',
       )
-      expect(output.stdout[0].toString()).toBe('@host first line\n')
-      expect(output.stderr[0].toString()).toBe('@host-err an error\n')
+      expect(output.stdout.toString()).toContain('@host first line\n')
+      expect(output.stderr.toString()).toContain('@host-err an error\n')
     })
   })
 })

--- a/packages/ssh-pool/src/Connection.test.js
+++ b/packages/ssh-pool/src/Connection.test.js
@@ -216,7 +216,7 @@ describe('Connection', () => {
       await connection.run('my-command -x', { tty: true })
 
       expect(exec).toHaveBeenCalledWith(
-        'ssh -tt user@host "sudo -u test my-command -x"',
+        'ssh -tt user@host "sudo -u test bash -c \'my-command -x\'"',
         {
           maxBuffer: 1000 * 1024,
         },
@@ -228,7 +228,7 @@ describe('Connection', () => {
       connection.run('sudo my-command -x', { tty: true })
 
       expect(exec).toHaveBeenCalledWith(
-        'ssh -tt user@host "sudo -u test my-command -x"',
+        'ssh -tt user@host "sudo -u test bash -c \'my-command -x\'"',
         {
           maxBuffer: 1000 * 1024,
         },

--- a/packages/ssh-pool/src/commands/mkdir.js
+++ b/packages/ssh-pool/src/commands/mkdir.js
@@ -1,7 +1,10 @@
 import { joinCommandArgs, requireArgs } from './util'
+import { formatRawCommand } from './raw'
 
-export function formatMkdirCommand({ folder }) {
+export function formatMkdirCommand({ asUser, folder }) {
   requireArgs(['folder'], { folder }, 'mkdir')
-  const args = ['mkdir', '-p', folder]
-  return joinCommandArgs(args)
+  return formatRawCommand({
+    asUser,
+    command: joinCommandArgs(['mkdir', '-p', folder]),
+  })
 }

--- a/packages/ssh-pool/src/commands/raw.js
+++ b/packages/ssh-pool/src/commands/raw.js
@@ -13,7 +13,9 @@ export function formatRawCommand({ asUser, command }) {
         'You should not use "sudo" and "asUser" options together. Please remove "sudo" from command.',
       )
     }
-    args = [...args, command.replace(SUDO_REGEXP, '')]
+
+    const commandWithoutSudo = command.replace(SUDO_REGEXP, '');
+    args = [...args, 'bash', '-c', `'${commandWithoutSudo}'`]
   } else if (command) args = [...args, command]
   return joinCommandArgs(args)
 }

--- a/packages/ssh-pool/src/commands/raw.test.js
+++ b/packages/ssh-pool/src/commands/raw.test.js
@@ -13,12 +13,12 @@ describe('raw', () => {
 
     it('should support asUser', () => {
       expect(formatRawCommand({ asUser: 'foo', command: 'echo "ok"' })).toBe(
-        'sudo -u foo echo "ok"',
+        'sudo -u foo bash -c \'echo "ok"\'',
       )
 
       expect(
         formatRawCommand({ asUser: 'foo', command: 'sudo echo "ok"' }),
-      ).toBe('sudo -u foo echo "ok"')
+      ).toBe('sudo -u foo bash -c \'echo "ok"\'')
     })
   })
 })

--- a/packages/ssh-pool/src/commands/rm.js
+++ b/packages/ssh-pool/src/commands/rm.js
@@ -1,7 +1,10 @@
 import { joinCommandArgs, requireArgs } from './util'
+import { formatRawCommand } from './raw'
 
-export function formatRmCommand({ file }) {
+export function formatRmCommand({ asUser, file }) {
   requireArgs(['file'], { file }, 'rm')
-  const args = ['rm', file]
-  return joinCommandArgs(args)
+  return formatRawCommand({
+    asUser,
+    command: joinCommandArgs(['rm', file]),
+  })
 }

--- a/packages/ssh-pool/src/commands/rsync.js
+++ b/packages/ssh-pool/src/commands/rsync.js
@@ -13,6 +13,7 @@ function formatExcludes(excludes) {
 }
 
 export function formatRsyncCommand({
+  asUser,
   src,
   dest,
   excludes,
@@ -21,6 +22,7 @@ export function formatRsyncCommand({
 }) {
   requireArgs(['src', 'dest'], { src, dest }, 'rsync')
   let args = ['rsync', '--archive', '--compress']
+  if (asUser) args = [...args, '--rsync-path', wrapCommand(`sudo -u ${asUser} rsync`)]
   if (additionalArgs) args = [...args, ...additionalArgs]
   if (excludes) args = [...args, ...formatExcludes(excludes)]
   if (remoteShell) args = [...args, '--rsh', wrapCommand(remoteShell)]

--- a/packages/ssh-pool/src/commands/tar.js
+++ b/packages/ssh-pool/src/commands/tar.js
@@ -18,7 +18,6 @@ export function formatTarCommand({ file, archive, excludes, mode }) {
     }
     case 'extract': {
       requireArgs(['archive'], { file, archive }, 'tar')
-      args = [...args, '--strip-components=1']
       args = [...args, '-xzf', archive]
       return joinCommandArgs(args)
     }

--- a/packages/ssh-pool/src/commands/tar.test.js
+++ b/packages/ssh-pool/src/commands/tar.test.js
@@ -54,7 +54,7 @@ describe('tar', () => {
           archive: 'file.tar.gz',
           mode: 'extract',
         }),
-      ).toBe('tar --strip-components=1 -xzf file.tar.gz')
+      ).toBe('tar -xzf file.tar.gz')
     })
 
     it('should support "excludes"', () => {


### PR DESCRIPTION
Added support of `asUser` to shipit.
`asUser` is already supported by ssh-pool because it was not exposed.

Also wrapped `asUser` command with `bash -c` to ensure that `if [ ... ]; then ..; fi;` is supported.